### PR TITLE
mysql and postgres group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'http://rubygems.org'
 
 gem 'rails', '3.2.14'
-gem 'mysql2'
-gem 'pg'
+gem 'mysql2', group: :mysql
+gem 'pg', group: :postgres
+
+gem "unicorn", "~> 4.8.2"
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     kaminari (0.14.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    kgio (2.9.2)
     less (2.3.2)
       commonjs (~> 0.2.6)
     less-rails (2.3.3)
@@ -158,6 +159,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
+    raindrops (0.13.0)
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
@@ -210,6 +212,10 @@ GEM
     uglifier (2.1.2)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    unicorn (4.8.3)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -250,3 +256,4 @@ DEPENDENCIES
   spreadsheet
   therubyracer
   uglifier (>= 1.0.3)
+  unicorn (~> 4.8.2)


### PR DESCRIPTION
Group mysql and postgres so that users can install only the required database as below.

Added unicorn gem and follow up patches include unicorn related files.
### For MySQL (note, the option says "without ... postgres")

$ bundle install --without development test postgres --deployment
### Or for PostgreSQL (note, the option says "without ... mysql")

$ bundle install --without development test mysql --deployment
