### PR TITLE
test case names stored as type text

### DIFF
--- a/db/migrate/20110629044935_create_test_cases.rb
+++ b/db/migrate/20110629044935_create_test_cases.rb
@@ -1,7 +1,7 @@
 class CreateTestCases < ActiveRecord::Migration
   def self.up
     create_table :test_cases do |t|
-      t.string :name
+      t.text :name
       t.text :description
 
       t.timestamps


### PR DESCRIPTION
- changed database storage type of test case names from string to text
  to allow longer names
