### PR TITLE
fix default value for link custom fields

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -59,7 +59,7 @@
                   <% else %>
                     False
                   <% end %>
-			   	<% elsif custom_item.custom_field.field_type == 'link' %>	
+			   	<% elsif custom_item.custom_field.field_type == 'link' && custom_item.value.split(',').count == 2 %>	
 			  		<%= link_to custom_item.value.split(',').map(&:strip).first, custom_item.value.split(',').map(&:strip).last, :target => "_blank" %>
                 <% else %>
                   <%= custom_item.value %>

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -30,7 +30,7 @@
                   <% else %>
                     False
                   <% end %>
-			   	<% elsif custom_item.custom_field.field_type == 'link' %>	
+			   	<% elsif custom_item.custom_field.field_type == 'link' && custom_item.value.split(',').count == 2 %>	
 			  		<%= link_to custom_item.value.split(',').map(&:strip).first, custom_item.value.split(',').map(&:strip).last, :target => "_blank" %>
                 <% else %>
                   <%= custom_item.value %>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -57,7 +57,7 @@
                   <% else %>
                     False
                   <% end %>
-			   	<% elsif custom_item.custom_field.field_type == 'link' %>	
+			   	<% elsif custom_item.custom_field.field_type == 'link' && custom_item.value.split(',').count == 2 %>	
 			  		<%= link_to custom_item.value.split(',').map(&:strip).first, custom_item.value.split(',').map(&:strip).last, :target => "_blank" %>
                 <% else %>
                   <%= custom_item.value %>

--- a/app/views/test_cases/show.html.erb
+++ b/app/views/test_cases/show.html.erb
@@ -85,7 +85,7 @@
                   <% else %>
                     False
                   <% end %>
-			   	<% elsif custom_item.custom_field.field_type == 'link' %>	
+			   	<% elsif custom_item.custom_field.field_type == 'link' && custom_item.value.split(',').count == 2 %>	
 			  		<%= link_to custom_item.value.split(',').map(&:strip).first, custom_item.value.split(',').map(&:strip).last, :target => "_blank" %>
                 <% else %>
                   <%= custom_item.value %>

--- a/app/views/test_plans/show.html.erb
+++ b/app/views/test_plans/show.html.erb
@@ -69,7 +69,7 @@
                   <% else %>
                     False
                   <% end %>
-			   	<% elsif custom_item.custom_field.field_type == 'link' %>	
+			   	<% elsif custom_item.custom_field.field_type == 'link' && custom_item.value.split(',').count == 2 %>	
 			  		<%= link_to custom_item.value.split(',').map(&:strip).first, custom_item.value.split(',').map(&:strip).last, :target => "_blank" %>
                 <% else %>
                   <%= custom_item.value %>


### PR DESCRIPTION
- new link type custom fields require two comma separated values for
  the link and display name
- previously if no value was set for the field it would display a link
  to the current testcasedb item’s page
- added fix to leave entry blank if the value is nothing
